### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/plos/_schema.yml
+++ b/_extensions/plos/_schema.yml
@@ -1,0 +1,34 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  plos-pdf:
+    keep-tex:
+      type: boolean
+      description: Keep intermediate LaTeX output after PDF render.
+    geometry:
+      type: array
+      items:
+        type: string
+      description: PDF page geometry options.
+    biblio-style:
+      type: string
+      description: BibTeX style file name for references.
+    natbiboptions:
+      type: string
+      description: Options passed to natbib package.
+    callout-appearance:
+      type: string
+      description: Callout style preset in the article.
+    callout-icon:
+      type: boolean
+      description: Toggle callout icons in rendered output.
+  plos-html:
+    number-sections:
+      type: boolean
+      description: Enable section numbering in HTML output.
+    toc:
+      type: boolean
+      description: Enable table of contents in HTML output.
+    theme:
+      type: string
+      description: HTML theme or SCSS file name.

--- a/_extensions/plos/_snippets.json
+++ b/_extensions/plos/_snippets.json
@@ -1,0 +1,25 @@
+{
+  "PLOS PDF format setup": {
+    "prefix": "pdf",
+    "body": [
+      "format:",
+      "  plos-pdf: default"
+    ],
+    "description": "Enable the PLOS PDF format."
+  },
+  "PLOS HTML format setup": {
+    "prefix": "html",
+    "body": [
+      "format:",
+      "  plos-html: default"
+    ],
+    "description": "Enable the PLOS HTML format."
+  },
+  "PLOS render command": {
+    "prefix": "render",
+    "body": [
+      "quarto render ${1:article.qmd} --to ${2:plos-pdf}"
+    ],
+    "description": "Render a document with a PLOS output format."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/plos/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/plos/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
